### PR TITLE
Fix docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o build/docker-mirr
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=0 /go/src/github.com/seatgeek/docker-mirror/build/docker-mirror /usr/local/bin/
-CMD ["./docker-mirror"]
+CMD ["/usr/local/bin/docker-mirror"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --update ca-certificates git \
 RUN go get -u github.com/golang/dep/cmd/dep
 WORKDIR /go/src/github.com/seatgeek/docker-mirror/
 COPY . /go/src/github.com/seatgeek/docker-mirror/
-RUN dep ensure
+RUN dep ensure -v
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o build/docker-mirror  .
 
 FROM alpine:latest


### PR DESCRIPTION
Hi, I've fixed docker entrypoint, the binary is placed in /usr/local/bin/ but
entrypoint was in ./docker-mirror, so when I ran image I got

```
docker: Error response from daemon: OCI runtime create failed:
container_linux.go:337: starting container process caused "exec:
\"./docker-mirror\": stat ./docker-mirror: no such file or directory": unknown.
```

I also added `-v` flag for `dep ensure`, so now we can see the progress while
downloading vendors.