### PR TITLE
add the option skip_remote_tags in the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ repositories:
       - "v*"
 
   - name: jippi/go-metadataproxy # import all tags
+
+  - name: docker.elastic.co/kibana/kibana-oss # The image is not hosted on Docker Hub
+    match_tag:
+      - "6.4.3"
+    skip_remote_tags: true # Do not fetch the tags from the registry, use the content of match_tag as existing tags
 ```
 
 ## Environment Variables

--- a/config.yaml
+++ b/config.yaml
@@ -29,3 +29,7 @@ repositories:
     match_tag:
       - "v*"
 
+  - name: docker.elastic.co/kibana/kibana-oss
+    match_tag:
+      - "6.4.3"
+    skip_remote_tags: true

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ type Repository struct {
 	RemoteTagSource string            `yaml:"remote_tags_source"`
 	RemoteTagConfig map[string]string `yaml:"remote_tags_config"`
 	TargetPrefix    *string           `yaml:"target_prefix"`
+	SkipRemoteTags  bool              `yaml:"skip_remote_tags"`
 }
 
 func main() {

--- a/mirror.go
+++ b/mirror.go
@@ -66,12 +66,24 @@ func (m *mirror) setup(repo Repository) (err error) {
 	}
 
 	// fetch remote tags
-	m.remoteTags, err = m.getRemoteTags()
+
+	if !m.repo.SkipRemoteTags {
+		m.remoteTags, err = m.getRemoteTags()
+	}
 	if err != nil {
 		return err
 	}
 
-	m.filterTags()
+	if !m.repo.SkipRemoteTags {
+		m.filterTags()
+	} else {
+		for _, tag := range m.repo.MatchTags {
+			repositoryTag := RepositoryTag{
+				Name: tag,
+			}
+			m.remoteTags = append(m.remoteTags, repositoryTag)
+		}
+	}
 
 	m.log = m.log.WithField("repo", m.repo.Name)
 	m.log = m.log.WithField("num_tags", len(m.remoteTags))


### PR DESCRIPTION
This option is useful when using images which are not hosted in docker hub, for example docker.elastic.co/kibana/kibana-oss

A solution more compatible with the current behaviour would be using the authentication of the registry, then list the tags: https://stackoverflow.com/questions/56050765/retrieve-docker-image-tags-from-a-3rd-party-repo

My take was to avoid doing this as it would probably not be compatible with all the docker images providers.