### PR TITLE
Read docker hub credentials from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,5 @@ repositories:
 Environment Variable  |  Default       | Description
 ----------------------| ---------------| -------------------------------------------------
 CONFIG_FILE           | config.yaml    | config file to use
+DOCKERHUB_USER        | unset          | optional user to authenticate to docker hub with
+DOCKERHUB_PASSWORD    | unset          | optional password to authenticate to docker hub with

--- a/mirror.go
+++ b/mirror.go
@@ -167,6 +167,7 @@ func (m *mirror) pullImage(tag string) error {
 
 	authConfig := docker.AuthConfiguration{}
 	if os.Getenv("DOCKERHUB_USER") != "" && os.Getenv("DOCKERHUB_PASSWORD") != "" {
+		m.log.Info("Using docker hub credentials from environment")
 		authConfig.Username = os.Getenv("DOCKERHUB_USER")
 		authConfig.Password = os.Getenv("DOCKERHUB_PASSWORD")
 	}

--- a/mirror.go
+++ b/mirror.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -164,7 +165,13 @@ func (m *mirror) pullImage(tag string) error {
 		OutputStream:      &logWriter{logger: m.log.WithField("docker_action", "pull")},
 	}
 
-	return m.dockerClient.PullImage(pullOptions, docker.AuthConfiguration{})
+	authConfig := docker.AuthConfiguration{}
+	if os.Getenv("DOCKERHUB_USER") != "" && os.Getenv("DOCKERHUB_PASSWORD") != "" {
+		authConfig.Username = os.Getenv("DOCKERHUB_USER")
+		authConfig.Password = os.Getenv("DOCKERHUB_PASSWORD")
+	}
+
+	return m.dockerClient.PullImage(pullOptions, authConfig)
 }
 
 // (re)tag the (local) docker image with the target repository name


### PR DESCRIPTION
Docker Hub has [introduced rate limiting for unauthenticated users](https://docs.docker.com/docker-hub/download-rate-limit/). If environment variables `DOCKERHUB_USER` and `DOCKERHUB_PASSWORD` are set those values are used to authenticate against Docker Hub when pulling source images.