### PR TITLE
Update aws cli usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It's possible to filter by docker tags, tag age and number of latest tags.
 
 ## Using
 
-Make sure that your local Docker agent is logged into to `ECR` (`eval $(aws ecr get-login --no-include-email --region us-east-1)`)
+Make sure that your local Docker agent is logged into to `ECR` (`aws ecr get-login-password --region us-east-1 | docker login -u AWS --password-stdin 093535234988.dkr.ecr.us-east-1.amazonaws.com`)
 
 `docker-mirror` will automatically create the ECR repository on demand, so you do not need to login and do any UI operations in the AWS Console.
 


### PR DESCRIPTION
The syntax used/documented in master only works for the v1 `aws` cli, this works with either (and is the recommended way to use the current cli https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html#cliv2-migration-ecr-get-login