### PR TITLE
Add the possiblity to cleanup mirrored images

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Make sure that your local Docker agent is logged into to `ECR` (`aws ecr get-log
 
 ```yml
 ---
+cleanup: true # (optional) Clean the mirrored images (default: false)
 target:
   # where to copy images to
   registry: ACCOUNT_ID.dkr.REGION.amazonaws.com

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ var (
 
 // Config is the result of the parsed yaml file
 type Config struct {
+	Cleanup      bool         `yaml:"cleanup"`
 	Workers      int          `yaml:"workers"`
 	Repositories []Repository `yaml:"repositories,flow"`
 	Target       TargetConfig `yaml:"target"`


### PR DESCRIPTION
I added an option into the yaml to clean images.
Prevent to keep all the images on a local docker