### PR TITLE
Release Pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,11 @@
-name: build
+name: release
 
-on: [push, pull_request]
+on:
+  release:
+    types: [published]
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-20.04
     steps:
     - name: Setup go
@@ -16,5 +18,9 @@ jobs:
       run: make -j dist
     - name: Test
       run: go test -timeout=600s -v
-    - name: List output
-      run: ls -la build
+    - name: Upload release assets
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: build/docker-mirror-linux-amd64
+        tag: ${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # docker-mirror
 
+[![build](https://github.com/seatgeek/docker-mirror/actions/workflows/build.yml/badge.svg)](https://github.com/seatgeek/docker-mirror/actions/workflows/build.yml)
+
 This project will copy public DockerHub repositories to a private registry.
 
 It's possible to filter by docker tags, tag age and number of latest tags.
@@ -7,12 +9,13 @@ It's possible to filter by docker tags, tag age and number of latest tags.
 <!-- TOC -->
 
 - [docker-mirror](#docker-mirror)
-    - [Install / Building](#install-building)
-    - [Using](#using)
-        - [Adding new mirror repository](#adding-new-mirror-repository)
-        - [Updating / resync an existing repository](#updating-resync-an-existing-repository)
-        - [Update all repositories](#update-all-repositories)
-    - [Example config.yaml](#example-configyaml)
+  - [Install / Building](#install--building)
+  - [Using](#using)
+    - [Adding new mirror repository](#adding-new-mirror-repository)
+    - [Updating / resync an existing repository](#updating--resync-an-existing-repository)
+    - [Update all repositories](#update-all-repositories)
+  - [Example config.yaml](#example-configyaml)
+  - [Environment Variables](#environment-variables)
 
 <!-- /TOC -->
 


### PR DESCRIPTION
- Tidy up build pipeline 
- Add release pipeline - whenever you publish a release on github it'll upload the build artifact
  - We should think about embedding the version in the build to make it identifiable 
  - Improve make file to generate not just the build version but all .e.g. mac, linux and arm versions of both
- Add build status to readme
