### PR TITLE
Add Private Docker Registry Config Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This project will copy public DockerHub repositories to a private registry.
 
-It's possible to filter by docker tags, tag age and number of latest tags, it is also possible to use a private docker registry.
+It's possible to filter by docker tags, tag age and number of latest tags, it is also possible to use a private docker registry. To use a private docker registry, add a line to your `config.yaml` file such as `private_registry: "private-registry-name"` and replace `private-registry-name` with the name of your private registry. This will prefix your docker pulls with the private registry name.
 
 <!-- TOC -->
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This project will copy public DockerHub repositories to a private registry.
 
-It's possible to filter by docker tags, tag age and number of latest tags.
+It's possible to filter by docker tags, tag age and number of latest tags, it is also possible to use a private docker registry.
 
 <!-- TOC -->
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 This project will copy public DockerHub repositories to a private registry.
 
-It's possible to filter by docker tags, tag age and number of latest tags, it is also possible to use a private docker registry. To use a private docker registry, add a line to your `config.yaml` file such as `private_registry: "private-registry-name"` and replace `private-registry-name` with the name of your private registry. This will prefix your docker pulls with the private registry name.
-
 <!-- TOC -->
 
 - [docker-mirror](#docker-mirror)
@@ -37,6 +35,20 @@ Make sure that your local Docker agent is logged into to `ECR` (`aws ecr get-log
 `docker-mirror` will automatically create the ECR repository on demand, so you do not need to login and do any UI operations in the AWS Console.
 
 `docker-mirror` will look for your AWS credentials in all the default locations (`env`, `~/.aws/` and so forth like normal AWS tools do)
+
+### Configuration File
+
+There are several configuration options you can use in your `config.yaml` below. Please see the `config.yaml` file in the repository for a full example.
+
+- `ignore_tag:` This option sets tags that can be ignored on pulls. (i.e. `ignore_tag: - "*-alpine"`)
+
+- `match_tag:` This option sets the tags that you want to match on for pulls. (i.e. `match_tag: - "3*"`)
+
+- `max_tag_age:` This option sets the max tag age you wish to pull from. (i.e. `max_tag_age: 4w`)
+
+- `name:` This option sets the name of your repository. (i.e. `name: elasticsearch`)
+
+- `private_registry:` This option allows you to set a private Docker registry prefix for docker pulls. It will prefix any of your `name:` options with the `private_registry` name and a slash to allow you to customize where your images are being pulled through. This is particularly useful if you use a proxy to dockerhub. i.e. (`private_registry: "private-registry-name"`)
 
 ### Adding new mirror repository
 

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,8 @@ target:
   prefix: "hub/"
 
 repositories:
-  - name: elasticsearch
+  - private_registry: "private-registry/",
+    name: elasticsearch
     max_tag_age: 4w
     ignore_tag:
       - "*-alpine"

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ target:
   prefix: "hub/"
 
 repositories:
-  - private_registry: "private-registry/",
+  - private_registry: "private-registry-name",
     name: elasticsearch
     max_tag_age: 4w
     ignore_tag:

--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ func worker(wg *sync.WaitGroup, workerCh chan Repository, dc *DockerClient, ecrm
 		select {
 		case repo := <-workerCh:
 			m := mirror{
-				dockerClient: dc,
+				dockerClient: *dc,
 				ecrManager:   ecrm,
 			}
 			if err := m.setup(repo); err != nil {

--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ func main() {
 
 	// start background workers
 	for i := 0; i < config.Workers; i++ {
-		go worker(&wg, workerCh, client, ecrManager)
+		go worker(&wg, workerCh, &client, ecrManager)
 	}
 
 	prefix := os.Getenv("PREFIX")
@@ -159,7 +159,7 @@ func main() {
 	log.Info("Done")
 }
 
-func worker(wg *sync.WaitGroup, workerCh chan Repository, dc DockerClient, ecrm *ecrManager) {
+func worker(wg *sync.WaitGroup, workerCh chan Repository, dc *DockerClient, ecrm *ecrManager) {
 	log.Debug("Starting worker")
 
 	for {

--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ func main() {
 
 	// start background workers
 	for i := 0; i < config.Workers; i++ {
-		go worker(&wg, workerCh, &client, ecrManager)
+		go worker(&wg, workerCh, client, ecrManager)
 	}
 
 	prefix := os.Getenv("PREFIX")
@@ -159,14 +159,14 @@ func main() {
 	log.Info("Done")
 }
 
-func worker(wg *sync.WaitGroup, workerCh chan Repository, dc *DockerClient, ecrm *ecrManager) {
+func worker(wg *sync.WaitGroup, workerCh chan Repository, dc DockerClient, ecrm *ecrManager) {
 	log.Debug("Starting worker")
 
 	for {
 		select {
 		case repo := <-workerCh:
 			m := mirror{
-				dockerClient: *dc,
+				dockerClient: dc,
 				ecrManager:   ecrm,
 			}
 			if err := m.setup(repo); err != nil {

--- a/mirror.go
+++ b/mirror.go
@@ -184,10 +184,10 @@ func (m *mirror) pullImage(tag string) error {
 
 	if m.repo.PrivateRegistry != "" {
 		pullOptions.Repository = m.repo.PrivateRegistry + m.repo.Name
-		return m.dockerClient.PullImage(pullOptions, authConfig)
+		return (*m.dockerClient).PullImage(pullOptions, authConfig)
 	}
 
-	return m.dockerClient.PullImage(pullOptions, authConfig)
+	return (*m.dockerClient).PullImage(pullOptions, authConfig)
 }
 
 // (re)tag the (local) docker image with the target repository name
@@ -201,7 +201,7 @@ func (m *mirror) tagImage(tag string) error {
 		Force: true,
 	}
 
-	return m.dockerClient.TagImage(fmt.Sprintf("%s:%s", m.repo.Name, tag), tagOptions)
+	return (*m.dockerClient).TagImage(fmt.Sprintf("%s:%s", m.repo.Name, tag), tagOptions)
 }
 
 // push the local (re)tagged image to the target docker registry
@@ -222,20 +222,20 @@ func (m *mirror) pushImage(tag string) error {
 		return err
 	}
 
-	return m.dockerClient.PushImage(pushOptions, *creds)
+	return (*m.dockerClient).PushImage(pushOptions, *creds)
 }
 
 func (m *mirror) deleteImage(tag string) error {
 	repository := fmt.Sprintf("%s:%s", m.repo.Name, tag)
 	m.log.Info("Cleaning images: " + repository)
-	err := m.dockerClient.RemoveImage(repository)
+	err := (*m.dockerClient).RemoveImage(repository)
 	if err != nil {
 		return err
 	}
 
 	target := fmt.Sprintf("%s/%s:%s", config.Target.Registry, m.targetRepositoryName(), tag)
 	m.log.Info("Cleaning images: " + target)
-	err = m.dockerClient.RemoveImage(target)
+	err = (*m.dockerClient).RemoveImage(target)
 	if err != nil {
 		return err
 	}

--- a/mirror.go
+++ b/mirror.go
@@ -57,7 +57,7 @@ type DockerClient interface {
 }
 
 type mirror struct {
-	dockerClient *DockerClient   // docker client used to pull, tag and push images
+	dockerClient DockerClient    // docker client used to pull, tag and push images
 	ecrManager   *ecrManager     // ECR manager, used to ensure the ECR repository exist
 	log          *log.Entry      // logrus logger with the relevant custom fields
 	repo         Repository      // repository the mirror
@@ -183,11 +183,11 @@ func (m *mirror) pullImage(tag string) error {
 	}
 
 	if m.repo.PrivateRegistry != "" {
-		pullOptions.Repository = m.repo.PrivateRegistry + m.repo.Name
-		return (*m.dockerClient).PullImage(pullOptions, authConfig)
+		pullOptions.Repository = m.repo.PrivateRegistry + "/" + m.repo.Name
+		return m.dockerClient.PullImage(pullOptions, authConfig)
 	}
 
-	return (*m.dockerClient).PullImage(pullOptions, authConfig)
+	return m.dockerClient.PullImage(pullOptions, authConfig)
 }
 
 // (re)tag the (local) docker image with the target repository name
@@ -201,7 +201,7 @@ func (m *mirror) tagImage(tag string) error {
 		Force: true,
 	}
 
-	return (*m.dockerClient).TagImage(fmt.Sprintf("%s:%s", m.repo.Name, tag), tagOptions)
+	return m.dockerClient.TagImage(fmt.Sprintf("%s:%s", m.repo.Name, tag), tagOptions)
 }
 
 // push the local (re)tagged image to the target docker registry
@@ -222,20 +222,20 @@ func (m *mirror) pushImage(tag string) error {
 		return err
 	}
 
-	return (*m.dockerClient).PushImage(pushOptions, *creds)
+	return m.dockerClient.PushImage(pushOptions, *creds)
 }
 
 func (m *mirror) deleteImage(tag string) error {
 	repository := fmt.Sprintf("%s:%s", m.repo.Name, tag)
 	m.log.Info("Cleaning images: " + repository)
-	err := (*m.dockerClient).RemoveImage(repository)
+	err := m.dockerClient.RemoveImage(repository)
 	if err != nil {
 		return err
 	}
 
 	target := fmt.Sprintf("%s/%s:%s", config.Target.Registry, m.targetRepositoryName(), tag)
 	m.log.Info("Cleaning images: " + target)
-	err = (*m.dockerClient).RemoveImage(target)
+	err = m.dockerClient.RemoveImage(target)
 	if err != nil {
 		return err
 	}

--- a/mirror_test.go
+++ b/mirror_test.go
@@ -4,6 +4,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	docker "github.com/fsouza/go-dockerclient"
 )
 
 func TestGetSleepTime(t *testing.T) {
@@ -37,6 +39,74 @@ func TestGetSleepTime(t *testing.T) {
 		t.Errorf("Expected %s got %s", expected, result)
 	}
 
+}
+
+type ResponseContainer struct {
+	TagImageName               string
+	TagImageOptions            docker.TagImageOptions
+	PullImageOptions           docker.PullImageOptions
+	PullImageAuthConfiguration docker.AuthConfiguration
+	PushImageOptions           docker.PushImageOptions
+	PushImageAuthConfiguration docker.AuthConfiguration
+	RemoveImageName            string
+}
+
+type TestDockerClient struct {
+	ResponseContainer *ResponseContainer
+}
+
+func (t *TestDockerClient) Info() (*docker.DockerInfo, error) {
+	return *docker.DockerInfo{}, nil
+}
+
+func (t *TestDockerClient) TagImage(name string, opts docker.TagImageOptions) error {
+	t.ResponseContainer.TagImageName = name
+	t.ResponseContainer.TagImageOptions = opts
+	return nil
+}
+
+func (t *TestDockerClient) PullImage(opts docker.PullImageOptions, authConfig docker.AuthConfiguration) error {
+	t.ResponseContainer.PullImageOptions = opts
+	t.ResponseContainer.PullImageAuthConfiguration = authConfig
+	return nil
+}
+
+func (t *TestDockerClient) PushImage(opts docker.PushImageOptions, auth docker.AuthConfiguration) error {
+	t.ResponseContainer.PushImageOptions = opts
+	t.ResponseContainer.PushImageAuthConfiguration = auth
+	return nil
+}
+
+func (t *TestDockerClient) RemoveImage(name string) error {
+	t.ResponseContainer.RemoveImageName = name
+	return nil
+}
+
+func CreateTestDockerClient(responseContainer *ResponseContainer) *TestDockerClient {
+	return &TestDockerClient{ResponseContainer: responseContainer}
+}
+
+func TestPullImage(t *testing.T) {
+	responseContainer := &ResponseContainer{}
+	var client DockerClient
+	client = CreateTestDockerClient(responseContainer)
+	repo := Repository{
+		PrivateRegistry: "private-registry/",
+		Name:            "elasticsearch",
+	}
+
+	m := mirror{
+		dockerClient: &client,
+	}
+	m.setup(repo)
+	m.pullImage("latest")
+
+	got := responseContainer.PullImageOptions.Repository
+	want := "private-registry/elasticsearch"
+
+	if got != want {
+		t.Errorf("Expected %q, got %q", want, got)
+	}
 }
 
 func getTimeAsString(date time.Time) string {

--- a/mirror_test.go
+++ b/mirror_test.go
@@ -87,26 +87,53 @@ func CreateTestDockerClient(responseContainer *ResponseContainer) *TestDockerCli
 }
 
 func TestPullImage(t *testing.T) {
-	responseContainer := &ResponseContainer{}
-	var client DockerClient
-	client = CreateTestDockerClient(responseContainer)
-	repo := Repository{
-		PrivateRegistry: "private-registry/",
-		Name:            "elasticsearch",
-	}
 
-	m := mirror{
-		dockerClient: &client,
-	}
-	m.setup(repo)
-	m.pullImage("latest")
+	t.Run("tests to ensure that PrivateRegistry creates the proper repo name", func(t *testing.T) {
+		responseContainer := &ResponseContainer{}
+		var client DockerClient
+		client = CreateTestDockerClient(responseContainer)
+		repo := Repository{
+			PrivateRegistry: "private-registry-name",
+			Name:            "elasticsearch",
+		}
 
-	got := responseContainer.PullImageOptions.Repository
-	want := "private-registry/elasticsearch"
+		m := mirror{
+			dockerClient: client,
+		}
 
-	if got != want {
-		t.Errorf("Expected %q, got %q", want, got)
-	}
+		m.setup(repo)
+		m.pullImage("latest")
+
+		got := responseContainer.PullImageOptions.Repository
+		want := "private-registry-name/elasticsearch"
+
+		if got != want {
+			t.Errorf("Expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("tests to ensure that without PrivateRegistry, a repo name is correct", func(t *testing.T) {
+		responseContainer := &ResponseContainer{}
+		var client DockerClient
+		client = CreateTestDockerClient(responseContainer)
+		repo := Repository{
+			Name: "elasticsearch",
+		}
+
+		m := mirror{
+			dockerClient: client,
+		}
+
+		m.setup(repo)
+		m.pullImage("latest")
+
+		got := responseContainer.PullImageOptions.Repository
+		want := "elasticsearch"
+
+		if got != want {
+			t.Errorf("Expected %q, got %q", want, got)
+		}
+	})
 }
 
 func getTimeAsString(date time.Time) string {

--- a/mirror_test.go
+++ b/mirror_test.go
@@ -98,7 +98,7 @@ func TestPullImage(t *testing.T) {
 		}
 
 		m := mirror{
-			dockerClient: client,
+			dockerClient: &client,
 		}
 
 		m.setup(repo)
@@ -121,7 +121,7 @@ func TestPullImage(t *testing.T) {
 		}
 
 		m := mirror{
-			dockerClient: client,
+			dockerClient: &client,
 		}
 
 		m.setup(repo)

--- a/mirror_test.go
+++ b/mirror_test.go
@@ -56,7 +56,7 @@ type TestDockerClient struct {
 }
 
 func (t *TestDockerClient) Info() (*docker.DockerInfo, error) {
-	return *docker.DockerInfo{}, nil
+	return &docker.DockerInfo{}, nil
 }
 
 func (t *TestDockerClient) TagImage(name string, opts docker.TagImageOptions) error {


### PR DESCRIPTION
This PR will add the option to specify a private docker registry for pulls, in the case you are using a remote proxy to a registry to avoid rate limitation on pulls. 